### PR TITLE
Update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ pandas-lineage is intended to extend the functionality of I/O and standard trans
 
 ## Badges:
 [![python-package](https://github.com/gage-russell/pandas-lineage/actions/workflows/python-package.yml/badge.svg)](https://github.com/gage-russell/pandas-lineage/actions/workflows/python-package.yml)
+[![pypi](https://img.shields.io/pypi/v/pandas-lineage)](https://pypi.org/project/pandas-lineage/)
 
 ## Installation
 `pip install pandas-lineage`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BEWARE: This project is in very early stages (as of 2022-09-12)
 pandas-lineage is intended to extend the functionality of I/O and standard transform operations on a pandas dataframe to emit OpenLineage RunEvents. I am starting just with read/write operations emiting RunEvents with schema facets.
 
 ## Badges:
-![python-package](https://github.com/gage-russell/pandas-lineage/actions/workflows/python-package.yml/badge.svg)
+[![python-package](https://github.com/gage-russell/pandas-lineage/actions/workflows/python-package.yml/badge.svg)](https://github.com/gage-russell/pandas-lineage/actions/workflows/python-package.yml)
 
 ## Installation
 `pip install pandas-lineage`


### PR DESCRIPTION
# Motivation

The existing readme only has a single badge to denote build status. However, it does not link to the CI results.

# Description

* Updates CI badge to include link to CI builds (went back and forth about whether to filter CI results to only `master` or not)
* Adds new badge (and link) to PYPI project with reference to latest released version (if latest github release was not pushed to pypi, this badge will be wrong)

Would recommend adding badge and link once other features are added (e.g. code coverage, project license, etc.)

# Testing

Verified correct links in rendered markdown in Github's UI.